### PR TITLE
Fix typo on install instructions

### DIFF
--- a/install.txt
+++ b/install.txt
@@ -1,4 +1,4 @@
-~ $ sgem install bunto
+~ $ gem install bunto
 ~ $ bunto --version
 ~ Bunto (v1.0)
 ~ $ bunto new mywebsite


### PR DESCRIPTION
The website had a typo on the install instructions, just a letter :-)